### PR TITLE
refactor: payment capture

### DIFF
--- a/lib/ui/views/payment_capture/payment_capture_view.dart
+++ b/lib/ui/views/payment_capture/payment_capture_view.dart
@@ -13,8 +13,9 @@ import 'payment_capture_viewmodel.dart';
     FormTextField(name: 'cardNumber'),
     FormTextField(name: 'cardOwner'),
     FormTextField(
-        name: 'cardExpiry',
-        validator: PaymentCaptureViewValidators.validateExpiryDate),
+      name: 'cardExpiry',
+      validator: PaymentCaptureViewValidators.validateExpiryDate,
+    ),
     FormTextField(
       name: 'cardCvv',
       validator: PaymentCaptureViewValidators.validateCvv,

--- a/lib/ui/views/payment_capture/payment_capture_viewmodel.dart
+++ b/lib/ui/views/payment_capture/payment_capture_viewmodel.dart
@@ -15,7 +15,7 @@ class PaymentCaptureViewModel extends FormViewModel {
   bool get canAccept =>
       !hasCardExpiryValidationMessage && !hasCardCvvValidationMessage;
 
-  Future<void> initializeForm() async {
+  void initializeForm() {
     cardOwnerValue = _userService.currentUser.fullName;
   }
 


### PR DESCRIPTION
For this case, `initializeForm` not need to be a Future so I changed that to avoid confusion when reading the chapter.