### PR TITLE
refactor: Google Sign In standalone widget

### DIFF
--- a/lib/ui/views/home/home_view.desktop.dart
+++ b/lib/ui/views/home/home_view.desktop.dart
@@ -1,6 +1,5 @@
 import 'package:filledstacked_academy/ui/common/app_colors.dart';
 import 'package:filledstacked_academy/ui/common/app_constants.dart';
-import 'package:filledstacked_academy/ui/common/app_strings.dart';
 import 'package:filledstacked_academy/ui/common/ui_helpers.dart';
 import 'package:filledstacked_academy/ui/views/home/home_view.form.dart';
 import 'package:filledstacked_academy/ui/views/home/home_viewmodel.dart';
@@ -8,7 +7,7 @@ import 'package:filledstacked_academy/ui/views/home/widgets/home_greet_user.dart
 import 'package:filledstacked_academy/ui/views/home/widgets/home_image.dart';
 import 'package:filledstacked_academy/ui/views/home/widgets/home_subtitle.dart';
 import 'package:filledstacked_academy/ui/views/home/widgets/home_title.dart';
-import 'package:filledstacked_academy/ui/widgets/common/academy_button.dart';
+import 'package:filledstacked_academy/ui/widgets/common/google_sign_in/google_sign_in.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:shimmer/shimmer.dart';
@@ -55,10 +54,7 @@ class HomeViewDesktop extends ViewModelWidget<HomeViewModel> {
                   children: [
                     viewModel.hasUser
                         ? const HomeGreetUser()
-                        : AcademyButton(
-                            title: ksCTASignInWithGoogle,
-                            onTap: viewModel.signInWithGoogle,
-                          ),
+                        : const GoogleSignIn(),
                   ],
                 ),
                 if (viewModel.showValidationError)

--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -43,22 +43,4 @@ class HomeViewModel extends FormViewModel {
   Future<void> navigateToUserProfile() async {
     await _routerService.navigateTo(const UserProfileViewRoute());
   }
-
-  Future<void> signInWithGoogle() async {
-    _log.i('');
-
-    unawaited(_analyticsService.logButtonClick(name: ksCTASignInWithGoogle));
-
-    final result = await runBusyFuture(_userService.signInWithGoogle());
-
-    if (result == SignInResult.failure) {
-      await _sheetService.showCustomSheet(
-        variant: BottomSheetType.notice,
-        title: 'Sign in failed',
-        description: 'Please, try again later or contact support',
-      );
-
-      return;
-    }
-  }
 }

--- a/lib/ui/widgets/common/google_sign_in/google_sign_in.dart
+++ b/lib/ui/widgets/common/google_sign_in/google_sign_in.dart
@@ -1,0 +1,34 @@
+import 'package:filledstacked_academy/ui/common/app_strings.dart';
+import 'package:filledstacked_academy/ui/widgets/common/academy_button.dart';
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+import 'google_sign_in_model.dart';
+
+class GoogleSignIn extends StackedView<GoogleSignInModel> {
+  final bool isBusy;
+  final bool enabled;
+  const GoogleSignIn({
+    Key? key,
+    this.isBusy = false,
+    this.enabled = true,
+  }) : super(key: key);
+
+  @override
+  Widget builder(
+    BuildContext context,
+    GoogleSignInModel viewModel,
+    Widget? child,
+  ) {
+    return AcademyButton(
+      enabled: enabled,
+      isBusy: isBusy || viewModel.isBusy,
+      onTap: viewModel.signInWithGoogle,
+      title: ksCTASignInWithGoogle,
+    );
+  }
+
+  @override
+  GoogleSignInModel viewModelBuilder(BuildContext context) =>
+      GoogleSignInModel();
+}

--- a/lib/ui/widgets/common/google_sign_in/google_sign_in_model.dart
+++ b/lib/ui/widgets/common/google_sign_in/google_sign_in_model.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:filledstacked_academy/app/app.locator.dart';
+import 'package:filledstacked_academy/app/app.logger.dart';
+import 'package:filledstacked_academy/enums/bottom_sheet_type.dart';
+import 'package:filledstacked_academy/enums/sign_in_result.dart';
+import 'package:filledstacked_academy/services/analytics_service.dart';
+import 'package:filledstacked_academy/services/user_service.dart';
+import 'package:filledstacked_academy/ui/common/app_strings.dart';
+import 'package:stacked/stacked.dart';
+import 'package:stacked_services/stacked_services.dart';
+
+class GoogleSignInModel extends BaseViewModel {
+  final log = getLogger('GoogleSignInModel');
+  final _analyticsService = locator<AnalyticsService>();
+  final _sheetService = locator<BottomSheetService>();
+  final _userService = locator<UserService>();
+
+  Future<void> signInWithGoogle() async {
+    log.i('');
+
+    unawaited(_analyticsService.logButtonClick(name: ksCTASignInWithGoogle));
+
+    final result = await runBusyFuture(_userService.signInWithGoogle());
+
+    if (result == SignInResult.failure) {
+      await _sheetService.showCustomSheet(
+        variant: BottomSheetType.notice,
+        title: 'Sign in failed',
+        description: 'Please, try again later or contact support',
+      );
+
+      return;
+    }
+  }
+}


### PR DESCRIPTION
Added a GoogleSignIn button widget which can be used anywhere and there is no need to add sign in logic to any other viewmodel.