### PR TITLE
Fix white placeholder between nested routes transitions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,8 +46,9 @@ class MyApp extends StatelessWidget {
         return MaterialApp.router(
           title: 'FilledStacks Academy',
           theme: Theme.of(context).copyWith(
-            primaryColor: kcBackgroundColor,
             focusColor: kcPrimaryColor,
+            primaryColor: kcBackgroundColor,
+            scaffoldBackgroundColor: Colors.transparent,
             textTheme: GoogleFonts.openSansTextTheme(
               Theme.of(context).textTheme,
             ).apply(


### PR DESCRIPTION
The native navigator can not be built without at least one page in the stack, AutoRouter uses a placeholder page if the stack is empty, the placeholder page uses the default scaffold's backgroundColor. Solution was to set scaffoldBackgroundColor on app Theme to Colors.transparent.